### PR TITLE
Register/Unregister event bus in onStart() and onStop() rather than o…

### DIFF
--- a/weekcalendar/src/main/java/noman/weekcalendar/adapter/PagerAdapter.java
+++ b/weekcalendar/src/main/java/noman/weekcalendar/adapter/PagerAdapter.java
@@ -61,6 +61,13 @@ public class PagerAdapter extends FragmentStatePagerAdapter {
         return date.plusDays(7);
     }
 
+    @Override
+    public int getItemPosition(Object object) {
+        //Force rerendering so the week is drawn again when you return to the view after
+        // back button press.
+        return POSITION_NONE;
+    }
+
     public void swipeBack() {
         date = date.plusDays(-7);
         currentPage--;

--- a/weekcalendar/src/main/java/noman/weekcalendar/eventbus/BusProvider.java
+++ b/weekcalendar/src/main/java/noman/weekcalendar/eventbus/BusProvider.java
@@ -6,12 +6,16 @@ import android.os.Looper;
 import com.squareup.otto.Bus;
 import com.squareup.otto.ThreadEnforcer;
 
+import java.util.ArrayList;
+import java.util.List;
+
 
 public final class BusProvider extends Bus {
 
     private static final Handler handler = new Handler(Looper.getMainLooper());
 
     private static BusProvider mInstance = null;
+    private List objects = new ArrayList();
 
     private BusProvider() {
         super(ThreadEnforcer.ANY);
@@ -39,5 +43,23 @@ public final class BusProvider extends Bus {
                 }
             });
         }
+    }
+
+    @Override
+    public void register(Object object) {
+        if (objects.contains(object)) {
+            return;
+        }
+        objects.add(object);
+        super.register(object);
+    }
+
+    @Override
+    public void unregister(Object object) {
+        if (!objects.contains(object)) {
+            return;
+        }
+        objects.remove(object);
+        super.unregister(object);
     }
 }

--- a/weekcalendar/src/main/java/noman/weekcalendar/fragment/WeekFragment.java
+++ b/weekcalendar/src/main/java/noman/weekcalendar/fragment/WeekFragment.java
@@ -101,13 +101,13 @@ public class WeekFragment extends Fragment {
     }
 
     @Override
-    public void onResume() {
+    public void onStart() {
         BusProvider.getInstance().register(this);
         super.onResume();
     }
 
     @Override
-    public void onPause() {
+    public void onStop() {
         BusProvider.getInstance().unregister(this);
         super.onPause();
     }

--- a/weekcalendar/src/main/java/noman/weekcalendar/fragment/WeekFragment.java
+++ b/weekcalendar/src/main/java/noman/weekcalendar/fragment/WeekFragment.java
@@ -103,13 +103,13 @@ public class WeekFragment extends Fragment {
     @Override
     public void onStart() {
         BusProvider.getInstance().register(this);
-        super.onResume();
+        super.onStart();
     }
 
     @Override
     public void onStop() {
         BusProvider.getInstance().unregister(this);
-        super.onPause();
+        super.onStop();
     }
 
     @Override

--- a/weekcalendar/src/main/java/noman/weekcalendar/view/WeekPager.java
+++ b/weekcalendar/src/main/java/noman/weekcalendar/view/WeekPager.java
@@ -2,6 +2,7 @@ package noman.weekcalendar.view;
 
 import android.content.Context;
 import android.content.res.TypedArray;
+import android.os.Parcelable;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.AppCompatActivity;
@@ -36,6 +37,21 @@ public class WeekPager extends ViewPager {
     public WeekPager(Context context, AttributeSet attrs) {
         super(context, attrs);
         initialize(attrs);
+    }
+
+    @Override
+    public void onRestoreInstanceState(Parcelable state) {
+        super.onRestoreInstanceState(state);
+        post(new Runnable() {
+            @Override
+            public void run() {
+                //Force rerendering so the week is drawn again when you return to the view after
+                // back button press.
+                if (adapter != null) {
+                    adapter.notifyDataSetChanged();
+                }
+            }
+        });
     }
 
     private void initialize(AttributeSet attrs) {


### PR DESCRIPTION
…nResume() and onPause().
This fixes the following exception:

> 08-01 13:32:35.053 27086-27086/xx.xxxx.crm E/AndroidRuntime: FATAL EXCEPTION: main
>                                                                   Process: xx.xxxx.crm, PID: 27086
>                                                                   java.lang.RuntimeException: Unable to pause activity {xx.xxxx.crm/xx.xxxx.crm.view.CoreActivity}: java.lang.IllegalArgumentException: Missing event handler for an annotated method. Is class noman.weekcalendar.fragment.WeekFragment registered?
>                                                                       at android.app.ActivityThread.performPauseActivity(ActivityThread.java:3381)
>                                                                       at android.app.ActivityThread.performPauseActivity(ActivityThread.java:3340)
>                                                                       at android.app.ActivityThread.handlePauseActivity(ActivityThread.java:3315)
>                                                                       at android.app.ActivityThread.-wrap13(ActivityThread.java)
>                                                                       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1355)
>                                                                       at android.os.Handler.dispatchMessage(Handler.java:102)
>                                                                       at android.os.Looper.loop(Looper.java:148)
>                                                                       at android.app.ActivityThread.main(ActivityThread.java:5417)
>                                                                       at java.lang.reflect.Method.invoke(Native Method)
>                                                                       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
>                                                                       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
>                                                                    Caused by: java.lang.IllegalArgumentException: Missing event handler for an annotated method. Is class noman.weekcalendar.fragment.WeekFragment registered?
>                                                                       at com.squareup.otto.Bus.unregister(Bus.java:290)
>                                                                       at noman.weekcalendar.fragment.WeekFragment.onPause(WeekFragment.java:111)
>                                                                       at android.support.v4.app.Fragment.performPause(Fragment.java:2253)
>                                                                       at android.support.v4.app.FragmentManagerImpl.moveToState(FragmentManager.java:1157)
>                                                                       at android.support.v4.app.FragmentManagerImpl.moveToState(FragmentManager.java:1286)
